### PR TITLE
Do not open the files with the O_SYNC flage

### DIFF
--- a/internal/service/files/service.go
+++ b/internal/service/files/service.go
@@ -68,7 +68,7 @@ func (s *FSService) Open(ctx context.Context, fileID uuid.UUID) (afero.File, err
 	idStr := string(fileID)
 	filePath := path.Join(idStr[:2], idStr)
 
-	file, err := s.fs.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_SYNC, 0o600)
+	file, err := s.fs.OpenFile(filePath, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("failed to Open %q: %w", filePath, err)
 	}


### PR DESCRIPTION
Forcing a flush for each write would increase the guarentees but it also increase the latency by ~1000x which is not viable